### PR TITLE
Integrate Docker build option into RGI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# base image (stripped down ubuntu for Docker)
+FROM phusion/baseimage
+
+# metadata
+LABEL base.image="ubuntu"
+LABEL version="1"
+LABEL software="RGI"
+LABEL software.version="4.0.2"
+LABEL description="Tool to identify resistance genes using the CARD database"
+LABEL website="https://card.mcmaster.ca/"
+LABEL documentation="https://github.com/arpcard/rgi/blob/master/README.rst"
+LABEL license="https://github.com/arpcard/rgi/blob/master/LICENSE"
+LABEL tags="Genomics"
+
+# maintainer
+MAINTAINER Finlay Maguire <finlaymaguire@gmail.com>
+
+# install system dependencies
+RUN \
+    apt-get update && \
+    apt-get install -y git python3 python3-dev python3-pip ncbi-blast+ prodigal wget && \
+    wget http://github.com/bbuchfink/diamond/releases/download/v0.8.36/diamond-linux64.tar.gz && \
+    tar xvf diamond-linux64.tar.gz && \
+    mv diamond /usr/bin
+
+# install and test rgi
+RUN git clone https://github.com/arpcard/rgi
+WORKDIR rgi/
+RUN pip3 install -r requirements.txt && \
+    pip3 install . && \
+    bash test.sh
+
+# sort the database path issue
+RUN pwd
+WORKDIR /usr
+RUN cp /rgi/card_data/card.json /usr/local/lib/python3.5/dist-packages/app/_data/card.json
+
+# move to workdir 
+WORKDIR /data/
+
+# set rgi executable as cmd to allow overriding
+CMD ["rgi"]
+

--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,39 @@ Clean previous or old databases
       rgi clean      
 
 
+Run RGI from docker
+-------------------
+
+- First you you must either pull the docker container from dockerhub (latest CARD version automatically installed)
+
+  // this should be changed to arpcard/rgi if you make a dockerhub account for arpcard and enable automated builds 
+  // https://docs.docker.com/docker-hub/builds/
+
+  .. code-block:: sh
+
+        docker pull finlaymaguire/rgi
+
+- Or Alternatively, build it locally from the Dockerfile (latest CARD version automatically installed)
+
+  .. code-block:: sh
+
+        git clone https://github.com/arpcard/rgi
+        docker build -t arpcard/rgi rgi
+
+- Then you can either run interactively (mounting a local directory called `rgi_data` in your current directory
+  to `/data/` within the container
+
+  .. code-block:: sh
+
+        docker run -i -v $PWD/rgi_data:/data -t arpcard/rgi bash
+
+- Or you can directly run the container as an executable with `$RGI_ARGS` being any of the commands described above.
+ Remember paths to input and outputs files are relative to the container (i.e. `/data/` if mounted as above. 
+  ..code-block:: sh
+        
+        docker run -v $PWD/rgi_data:/data arpcard/rgi $RGI_ARGS
+       
+
 Support & Bug Reports
 ----------------------
 


### PR DESCRIPTION
Add Dockerfile to allow local and automated Dockerhub dockerbuilds

Automatic Dockerhub builds currently build under my dockerhub account but can be configured for an CARD dockerhub account fairly easily (`https://docs.docker.com/docker-hub/builds/`).

Updated documentation to explain how to use docker version of RGI

Should resolve #9 