### PR TITLE
Flexible python3 shebang for cli entrypoint

### DIFF
--- a/rgi
+++ b/rgi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 from app.MainBase import MainBase
 
 MainBase()


### PR DESCRIPTION
To accommodate use of virtual environments and different python install paths.

Upon install into virtual environment I wasn't able to immediately use the rgi command.  Changing the shebang allowed for more flexible use.

See "Impact on Script Launching": https://www.python.org/dev/peps/pep-0486/

Optional: use agnostic python instead of python3; except that python 3.6 is specified as a requirement.