### PR TITLE
Load all databases in docker image/file

### DIFF
--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -47,7 +47,27 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag image $IMAGE_ID:$VERSION
+
+          docker build . --file Dockerfile --tag $IMAGE_ID:$VERSION
 
       - name: Log into registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
@@ -71,5 +91,4 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
-          docker tag image $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -88,7 +88,4 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
 
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
           docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/dockerpublish.yml
+++ b/.github/workflows/dockerpublish.yml
@@ -1,0 +1,75 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  IMAGE_NAME: rgi
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file Dockerfile
+          fi
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag image $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,29 @@ RUN conda create --name rgi --channel conda-forge --channel bioconda rgi
 RUN mkdir -p /card_data
 WORKDIR /card_data
 RUN wget -O data.tar.bz2 https://card.mcmaster.ca/latest/data && \
-        tar xvf data.tar.bz2 && pwd && ls
-# install database
-SHELL ["conda", "run", "-n", "rgi", "rgi", "load", "-i", "/card_data/card.json"]
+        mkdir -p canonical &&  tar xf data.tar.bz2 -C canonical
+
+# download wildcard data (modified from @nebfield)
+RUN wget -O wildcard_data.tar.bz2 https://card.mcmaster.ca/latest/variants && \
+    mkdir -p wildcard && \
+    tar xf wildcard_data.tar.bz2 -C wildcard && \
+        gunzip wildcard/*.gz
+
+# install CARD database
+SHELL ["conda", "run", "-n", "rgi", "card_annotation", "-i",  "canonical/card.json", ">", "card_annotation.log", "2>&1"]
+SHELL ["conda", "run", "-n", "rgi", "rgi", "load", "-i", "caonical/card.json", "--card_annotation", "card_database_*.fasta"]
+
+# install WILDCARD database
+# version number not in downloaded data so can't do this in a way that will
+# automatically be entered
+SHELL ["conda", "run", "-n", "rgi", "rgi", "wildcard_annotation", "-i", "wildcard", "--card_json", "canonical/card.json", "-v", "docker_version_number", ">", "wildcard_annotation.log", "2>&1"]
+SHELL ["conda", "run", "-n", "rgi", "rgi", "load", "--wildcard_annotation", "wildcard_database*", "--wildcard_index", "wildcard/index-for-model-sequences.txt", "--card_annotation", "card_database*"]
+
+# install kmer pathogen-of-origin database
+SHELL ["conda", "run", "-n", "rgi", "rgi", "load", "--kmer_database", "wildcard/61_kmer_db.json", "--amr_kmers", "wildcard/all_amr_61mers.txt", "--kmer_size", "61", "--debug", ">", "kmer_load.61.log", "2>&1"]
+
+# Remove non-loaded databases to reduce container size
+RUN cp *.log /data && rm -rf /card_data
 
 WORKDIR /data
 # set rgi executable as cmd to allow overriding

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM continuumio/miniconda3
 
 # metadata
-LABEL base.image="miniuonda3"
+LABEL base.image="miniconda3"
 LABEL version="2"
 LABEL software="RGI"
 LABEL description="Tool to identify resistance genes using the CARD database"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,29 +24,34 @@ RUN conda create --name rgi --channel conda-forge --channel bioconda rgi
 RUN mkdir -p /card_data
 WORKDIR /card_data
 RUN wget -O data.tar.bz2 https://card.mcmaster.ca/latest/data && \
-        mkdir -p canonical &&  tar xf data.tar.bz2 -C canonical
+        mkdir -p canonical &&  tar xf data.tar.bz2 -C canonical && \
+        rm data.tar.bz2
 
 # download wildcard data (modified from @nebfield)
 RUN wget -O wildcard_data.tar.bz2 https://card.mcmaster.ca/latest/variants && \
     mkdir -p wildcard && \
     tar xf wildcard_data.tar.bz2 -C wildcard && \
-        gunzip wildcard/*.gz
+        gunzip wildcard/*.gz && rm wildcard_data.tar.bz2
+     
 
 # configure conda shell
 SHELL ["conda", "run", "-n", "rgi", "/bin/bash", "-c"]
 
 # install CARD database
 RUN rgi card_annotation -i canonical/card.json > card_annotation.log 2>&1 && \
-    rgi load --local -i canonical/card.json --card_annotation card_database_*.fasta
+    rgi load -i canonical/card.json --card_annotation card_database_v*.fasta
 
 # install WILDCARD database
 # version number not in downloaded data so can't do this in a way that will
 # automatically be entered if the wildcard download contained a version file etc
-RUN rgi wildcard_annotation -i wildcard --card_json canonical/card.json -v latest > wildcard_annotation.log 2>&1 && \
-    rgi load --local --wildcard_annotation wildcard_database* --wildcard_index wildcard/index-for-model-sequences.txt --card_annotation card_database*
+RUN rgi wildcard_annotation -i wildcard --card_json canonical/card.json -v docker_latest_version > wildcard_annotation.log 2>&1 &&\
+    rgi load --wildcard_annotation wildcard_database_v*.fasta --wildcard_index wildcard/index-for-model-sequences.txt --card_annotation card_database_v*.fasta 
 
 # install kmer pathogen-of-origin database
-RUN rgi load --local --kmer_database wildcard/61_kmer_db.json --amr_kmers wildcard/all_amr_61mers.txt --kmer_size 61 --debug > kmer_load.61.log 2>&1
+RUN rgi load --kmer_database wildcard/61_kmer_db.json --amr_kmers wildcard/all_amr_61mers.txt --kmer_size 61 --debug > kmer_load.61.log 2>&1
+
+# tidy up databases 
+RUN mkdir -p /card_logs && cp *.log /card_logs && rm -rf /card_data
 
 # Move to workdir
 WORKDIR /data


### PR DESCRIPTION
As per the idea from @nebfield I've updated the `Dockerfile` to install all the databases.

Only minor issue is there is no easy way to check what version of wildCARD/CARD R&V has been downloaded so the version isn't correct.  @raphenya don't suppose you can add a file that contains the version metadata the wildCARD/CARD R&V tarball? 

This also adds a github action to autobuild the container on a new release, but I'm not totally sure this will work seamlessly so might need some tinkering @raphenya 

Closes #126