### PR TITLE
Fix infinite loop if fasta is empty

### DIFF
--- a/app/kmer_query.py
+++ b/app/kmer_query.py
@@ -174,7 +174,7 @@ class CARDkmers(object):
         temp_iterator = SeqIO.parse(file, "fasta")
         ns = sum(1 for i in temp_iterator) # counts number of sequences in generator
         list_size = math.ceil(ns/self.threads) # maximizes list size for threads available
-        split_sequences = list(self.chunk_list(iterator, list_size)) # returns a list of lists
+        split_sequences = list(self.chunk_list(iterator, list_size)) if list_size > 0 else [[]] # returns a list of lists
         logger.info("Using {t} threads to query {s} sequences".format(t=self.threads, s=ns))
         return split_sequences
 


### PR DESCRIPTION
* If the incoming bam file has no alignments to the database, the fasta file is empty
* Since the fasta file is empty, list_size is 0
* passing a list_size of 0 to chunk_list gets stuck in an infinite loop
* This PR returns an empty list of lists; the rest of the code seems well defined enough to output appropriate empty outputs