### PR TITLE
change conda_env.yml to match requirements.txt

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -14,10 +14,11 @@ dependencies:
   - seaborn >= 0.8.1
   - pyfaidx >= 0.5.4.1
   - pyahocorasick 1.4.0
-  - pysam 0.16.0.1
-  - beautifulsoup4 4.9.3
-  - requests 2.24.0
-  - lxml 4.6.1
+  - pysam >= 0.16.0.1
+  - beautifulsoup4 >= 4.9.3
+  - requests 2.31.0
+  - lxml >= 4.9.1
+  - dask
   - blast 2.9.0
   - zlib
   - prodigal 2.6.3


### PR DESCRIPTION
I was under the impression that 3.6 was the minimum python version, so not sure if 3.5 here is a mistake or intentional.