### PR TITLE
add dask and jellyfish to conda_env

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -30,3 +30,5 @@ dependencies:
   - bowtie2 >=2.3.4.3
   - bwa >=0.7.17
   - kma >=1.2.26s
+  - bioconda::jellyfish
+  - dask


### PR DESCRIPTION
```
./rgi database --version
Traceback (most recent call last):
  File "./rgi", line 2, in <module>
    from app.MainBase import MainBase
  File "/home/hunglin/p5/projects/forks/rgi/app/MainBase.py", line 16, in <module>
    from app.BWT import BWT
  File "/home/hunglin/p5/projects/forks/rgi/app/BWT.py", line 9, in <module>
    import dask.dataframe as dd
ModuleNotFoundError: No module named 'dask'
```

```
./test.sh
./test.sh: line 18: jellyfish: command not found
```
