### PR TITLE
Update `pyrodigal` to` v3.0`

### DIFF
--- a/app/ORF.py
+++ b/app/ORF.py
@@ -245,11 +245,11 @@ class PyORF(object):
 		if self.training_file is not None:
 			with open(self.training_file, "rb") as src:
 				training_info = pyrodigal.TrainingInfo.load(src)
-			orf_finder = pyrodigal.OrfFinder(meta=False, mask=True, training_info=training_info)
+			orf_finder = pyrodigal.GeneFinder(meta=False, mask=True, training_info=training_info)
 		elif self.low_quality or minimum_sequence_length < 20000:
-			orf_finder = pyrodigal.OrfFinder(meta=True, mask=True)
+			orf_finder = pyrodigal.GeneFinder(meta=True, mask=True)
 		else:
-			orf_finder = pyrodigal.OrfFinder(meta=False, mask=True)
+			orf_finder = pyrodigal.GeneFinder(meta=False, mask=True)
 			orf_finder.train(*sequences, force_nonsd=True)
 
 		with contextlib.ExitStack() as stack:

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -21,7 +21,7 @@ dependencies:
   - blast 2.14.1
   - zlib
   - prodigal 2.6.3
-  - pyrodigal >=2.0.0
+  - pyrodigal >=3.0.0
   - diamond 0.8.36
   - oligoarrayaux 3.8
   - samtools 1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ beautifulsoup4>=4.9.3
 requests==2.31.0
 lxml>=4.9.1
 dask[dataframe]
-pyrodigal>=2.0.0
+pyrodigal>=3.0.0
 setuptools>=47.1.0


### PR DESCRIPTION
Hi!

This PR updates the Pyrodigal annotation to use Pyrodigal 3.0 (which has bugfixes and more, but renamed the `OrfFinder` class to `GeneFinder` for consistency with the `find_genes` method).