### PR TITLE
Added argument to include loose hits in the heatmap

### DIFF
--- a/app/Heatmap.py
+++ b/app/Heatmap.py
@@ -14,10 +14,11 @@ class Heatmap(object):
     This is a program that genreates a heatmap of multiple RGI analyses.
     """
 
-    def __init__(self, input, classification, frequency, output, cluster, display, debug):
+    def __init__(self, input, classification, frequency, include_loose,output, cluster, display, debug):
         self.input = input
         self.classification = classification
         self.frequency = frequency
+        self.include_loose = include_loose
         self.output = output
         self.cluster = cluster
         self.display = display
@@ -332,7 +333,7 @@ class Heatmap(object):
                         hsp = max(value.keys(), key=(lambda key: value[key]['bit_score']))
 
                         # Flag to exclude loose hits
-                        if value[hsp]["type_match"] != "Loose":
+                        if value[hsp]["type_match"] != "Loose" or self.include_loose:
                             topmodel = value[hsp]["model_name"]
                             tophits[topmodel] = value[hsp]["type_match"]
 
@@ -409,7 +410,7 @@ class Heatmap(object):
         genelist = sorted(genelist)
 
         # Create a dictionary that will convert type of hit to num. value
-        conversion = {"Perfect": 2, "Strict": 1}
+        conversion = {"Perfect": 3, "Strict": 2, "Loose": 1}
 
         # Apply conversion so hit criteria is number based
         for sample in genes:
@@ -428,7 +429,7 @@ class Heatmap(object):
 
         # Fixed colourmap values (purple, teal, yellow)
         cmap_values = [0, 1, 2, 3]
-        custom_cmap = matplotlib.colors.ListedColormap(['#4c0057', '#00948f', '#feed00'])
+        custom_cmap = matplotlib.colors.ListedColormap(['#000000', '#4c0057', '#00948f', '#feed00'])
         norm = matplotlib.colors.BoundaryNorm(cmap_values, custom_cmap.N)
 
         # If the classification option chosen:
@@ -848,15 +849,16 @@ class Heatmap(object):
                     print('Output file %s: AMR genes are listed in alphabetical order '
                     'and samples have been clustered hierarchically (see SciPy documentation). '
                     'Yellow represents a perfect hit, teal represents a strict hit, purple '
-                    'represents no hit.' %(file_name))
+                    'represents a loose hit, black represents no hit.' %(file_name))
                 elif self.cluster == 'genes':
                     print('Output file %s: AMR genes have been clustered hierarchically. '
                     'Yellow represents a perfect hit, teal represents a strict hit, purple '
-                    'represents no hit.' %(file_name))
+                    'represents a loose hit, black represents no hit.' %(file_name))
                 elif self.cluster == 'both':
                     print('Output file %s: AMR genes and samples have been clustered hierarchically '
                     '(see SciPy documentation). Yellow represents a perfect hit, teal represents a strict hit, purple '
-                    'represents no hit.' %(file_name))
+                    'represents a loose hit, black represents no hit.' %(file_name))
                 else:
                     print('Output file %s: Yellow represents a perfect hit, '
-                    'teal represents a strict hit, purple represents no hit.' %(file_name))
+                    'teal represents a strict hit, purple represents a loose hit,'
+                    ' black represents  no hit.' %(file_name))

--- a/app/MainBase.py
+++ b/app/MainBase.py
@@ -388,6 +388,8 @@ class MainBase(object):
                             help="The option to organize resistance genes based on a category.")
         parser.add_argument('-f', '--frequency', dest="frequency", action="store_true",
                             help="Represent samples based on resistance profile.")
+        parser.add_argument('-l', '--include_loose', dest="include_loose", action="store_true",
+                            help="Include loose predictions.")
         parser.add_argument('-o', '--output', dest="output", default="RGI_heatmap",
                             help="Name for the output EPS and PNG files.\nThe number of files run will automatically \nbe appended to the end of the file name.(default={})".format('RGI_heatmap'))
         parser.add_argument('-clus', '--cluster', dest="cluster", choices=("samples", "genes", "both"),
@@ -400,7 +402,7 @@ class MainBase(object):
         return parser
 
     def heatmap_run(self, args):
-        obj = Heatmap(args.input, args.classification, args.frequency,
+        obj = Heatmap(args.input, args.classification, args.frequency, args.include_loose,
                       args.output, args.cluster, args.display, args.debug)
         obj.run()
 


### PR DESCRIPTION
Loose hits are now possibly included in the heatmap using the argument `--include_loose`. Their color is purple and black  now represents no hit.

```
./rgi heatmap -i tests/outputs/NC_020818.1.json -o tests/outputs/heatmap_test_to_remove
./rgi heatmap -i tests/outputs/ -o tests/outputs/heatmap_test_to_remove_loose_hits --include_loose
./rgi heatmap -i tests/outputs/ -o tests/outputs/heatmap_test_to_remove
```
Produces:
<img width="341" height="521" alt="heatmap_test_to_remove-1" src="https://github.com/user-attachments/assets/52e67f68-4e2e-4a02-8874-2f47b91dc89c" />
<img width="1037" height="3139" alt="heatmap_test_to_remove_loose_hits-1" src="https://github.com/user-attachments/assets/79482a09-e0ba-466b-a2d5-7a26d86bdf8f" />
This might be useful for exploration purpose (e.g. environment that is not well characterized). This was not vibe coded.